### PR TITLE
1931_회의실 배정

### DIFF
--- a/kuyho.chung/1931_회의실 배정.kt
+++ b/kuyho.chung/1931_회의실 배정.kt
@@ -1,0 +1,46 @@
+// 문제 링크: https://www.acmicpc.net/problem/1931
+import java.io.BufferedReader
+import java.io.InputStreamReader
+import java.util.*
+
+fun main() {
+    // 입력을 위한 bufferReader
+    val br = BufferedReader(InputStreamReader(System.`in`))
+    // 오름차순 정렬을 위한 lambda
+    var lambda = {a:Int, b:Int ->
+        when {
+            a < b -> -1
+            a > b -> 1
+            else -> 0
+        }
+    }
+    // first: 시작시간, second: 종료시간
+    // second 시간을 오름차순으로 정렬하고,
+    // second가 같은 경우 first를 오름차순으로 정렬
+    val pq = PriorityQueue<Pair<Int, Int>>(Comparator<Pair<Int, Int>>{a, b
+        ->
+        when {
+            a.second != b.second -> lambda(a.second, b.second)
+            else -> lambda(a.first, b.first)
+        }
+    })
+
+    // 입력
+    var curTime = 0
+    var answer = 0
+    val n:Int = br.readLine()!!.toInt()
+    for (i in 1..n) {
+        val input = br.readLine()
+        val fromto = input.split(' ')
+        pq.add(Pair(fromto[0].toInt(),fromto[1].toInt()))
+    }
+
+    while (pq.isNotEmpty()) {
+        if (pq.peek().first >= curTime) {
+            curTime = pq.peek().second
+            answer++
+        }
+        pq.remove()
+    }
+    println(answer)
+}


### PR DESCRIPTION
다음을 기준으로 정렬하였습니다.
회의 [시작 시간, 종료 시간] 중 종료 시간을 먼저 오름차순으로 정렬하고,
종료시간 값이 같은 항목들은 시작 시간을 오름차순으로 정렬하였습니다.

answer = 0, currentTime = 0으로 초기화합니다.
정렬된 원소들을 앞에서부터 탐색하며,
만약 다음 원소의 시작시간이 currentTime보다 같거나 크다면,
* currentTime = 다음원소.종료시간
* answer++